### PR TITLE
Fix conflicting references to the Closure Library download path

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var mkdirp = require('mkdirp');
 var ncp = require('ncp');
 
-var downloadDir = path.join(__dirname, 'bin');
+var downloadDir = path.join(__dirname, 'lib');
 
 module.exports = function(installDir) {
 	if (!fs.existsSync(installDir)) {


### PR DESCRIPTION
`install.js` is extracting the Closure Library into a `lib` directory, but `index.js` is looking for those files in a `bin` directory.  This Pull Request will correct the latter script to look in the `lib` directory.
