### PR TITLE
Use the synchronous version of mkdirp

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var downloadDir = path.join(__dirname, 'bin');
 
 module.exports = function(installDir) {
 	if (!fs.existsSync(installDir)) {
-		mkdirp(installDir);
+		mkdirp.sync(installDir);
 	}
 	
 	if (fs.existsSync(installDir) && fs.statSync(installDir).isDirectory()) {


### PR DESCRIPTION
Per issue #3, the setup script should use the synchronous version of `mkdirp` to create the destination if it's missing.  Otherwise the setup will proceed before the destination exists, causing setup to abort.
