### PR TITLE
Upgrade to callback API for download package

### DIFF
--- a/install.js
+++ b/install.js
@@ -6,13 +6,14 @@ var download = require('download');
 var closureToolsUrls = 'https://github.com/google/closure-library/archive/master.zip';
 var downloadDir = path.join(__dirname, 'lib');
 
-var closureToolsDownload = download(closureToolsUrls, downloadDir, { extract: true , strip: 1});
+var closureToolsDownload = download({ extract: true , strip: 1})
+	.get(closureToolsUrls)
+	.dest(downloadDir);
 
-closureToolsDownload.on('error', function(err){
-	if (err) {
+closureToolsDownload.run(function(err, files){
+	if(err) {
 		throw new Error('Failed to download "' + closureToolsUrls + '"!\n' + err);
 	}
-});
-closureToolsDownload.on('close', function(){
+	
 	console.log('Successfully downloaded "' + closureToolsUrls + '" to:\n    ' + downloadDir);
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/vsonix-bub/node-google-closure-library-latest",
   "dependencies": {
-    "download": "^0.1.17",
+    "download": "^4.0.1",
     "mkdirp": "^0.3.5",
     "ncp": "^0.5.1",
     "path": "^0.4.9"


### PR DESCRIPTION
The version of `download` that is currently used has a bug where the `close` event runs once the download completes, but not necessarily after the extraction completes (see https://github.com/kevva/download/issues/18).  This is fixed by newer versions of `download` which use a completely different API.  This Pull Request will update the `download` dependency and the installation script to follow the new API.  Helps address issue #3.
